### PR TITLE
Set KSPAssembly in AssemblyVersion.tt

### DIFF
--- a/B9PartSwitch/AssemblyVersion.tt
+++ b/B9PartSwitch/AssemblyVersion.tt
@@ -99,3 +99,4 @@
 
  [assembly: AssemblyVersion("<#= major #>.<#= minor #>.<#= patch #>.<#= build #>")]
  [assembly: AssemblyFileVersion("<#= major #>.<#= minor #>.<#= patch #>.<#= build #>")]
+ [assembly: KSPAssembly("B9PartSwitch", <#= major #>, <#= minor #>, <#= patch #>)]


### PR DESCRIPTION
Hi @linuxgurugamer,

It was noted that this DLL currently doesn't set `KSPAssembly`, unlike previous releases, which is currently breaking other mods that depend on it.

Checking SpaceTuxLibrary's `AssemblyVersion.tt` file, it looks like 4f9820755b5c7d5616df4c2c7e0afa4b6c5697b9 should have been followed up by adding an equivalent line to `AssemblyVersion.tt`. This PR adds that.

Cheers!
