### PR TITLE
Modified GetInfo to suppress info about texture only changes. 

### DIFF
--- a/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
+++ b/B9PartSwitch/PartSwitch/ModuleB9PartSwitch.cs
@@ -229,13 +229,32 @@ namespace B9PartSwitch
 
         public override string GetInfo()
         {
+	    // Rearrange building string used in VAB PartInfo popup, so that it is
+	    // only defined for tanks that switch resources. This is to drop side
+            // panels that just list multiple texture changes adding clutter with
+            // no functionally useful data about the part.
+
             InitializeSubtypes();
-            string outStr = $"<b><color=#7fdfffff>{SubtypesCount} {switcherDescriptionPlural}</color></b>";
+            string outStr = " "; // just to keep it from being undefined and throwing an error.
+
+            bool onetime = true;  // For subtype count and desciption
             foreach (var subtype in subtypes)
             {
-                outStr += $"\n<b>- {subtype.title}</b>";
+                bool first = true; // for subtype title
                 foreach (var resource in subtype.tankType)
-                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * GetTotalVolume(subtype) :0.#}";
+                {
+                    if (onetime)
+                    {
+                        onetime = false;
+                        outStr = $"<b><color=#7fdfffff>{SubtypesCount} {switcherDescriptionPlural}</color></b>";
+                    }
+                    if (first)
+                    {
+                        first = false;
+                        outStr += $"\n<b>- {subtype.title}</b>";
+                    }
+                    outStr += $"\n  <color=#99ff00ff>- {resource.resourceDefinition.displayName}</color>: {resource.unitsPerVolume * GetTotalVolume(subtype):0.#}";
+                }
             }
             return outStr;
         }


### PR DESCRIPTION
I was annoyed with several parts that use B9PS for texture changes that end up cluttering the part info popup in the VAB. These do not have a functional impact on the part, and I find the information unhelpful.  

Before: 14 Texture Subtypes for 3 models (one skin and 2 endcaps). This info alone takes the entire screen height of the Part Info side menu and I'm still not to the the 6 Subtype descriptions that actually matter for different resources.
<img width="793" height="500" alt="screenshot2" src="https://github.com/user-attachments/assets/a5ca4a5b-fffd-45b8-a997-5cb131d9bf52" />

After: only info for the variants that change resources are presented. The previous textures used to be between the Crew Report definition that you can see the tail of at the top of the screen and the Part Subtypes still listed.
<img width="797" height="501" alt="screenshot3" src="https://github.com/user-attachments/assets/a5c0c1f5-0179-4ef1-91a8-db87bf453ea8" />

The part switcher still works for textures once the part is placed in the VAB, but since the Part Info doesn't mention texture variants it isn't clear from the thumbnail view which parts have texture options. It will probably confuse a lot of people that aren't aware of all the features in their mods. I'm using it mainly because of Nertea's habit of defining the skin of a part with one part switcher and then two more for each of the end caps. It just adds a lot of clutter. It would probably be better to have a flag in the part module definition to suppress the info that a user could add with a patch, but this was the quickest for me to implement for my game. One bug I have seen is that if one of the variants is empty (no resources) version the subtype count includes this, but the no resource variant isn't listed in the Subtypes.

I'll leave it up to the maintainers to decide if it's worth making this change.